### PR TITLE
feat: add windows support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,15 +64,28 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use_cross: false
+            bin_name: darya
+            archive_ext: tar.gz
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use_cross: true
+            bin_name: darya
+            archive_ext: tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
             use_cross: false
+            bin_name: darya
+            archive_ext: tar.gz
           - os: macos-latest
             target: aarch64-apple-darwin
             use_cross: false
+            bin_name: darya
+            archive_ext: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use_cross: false
+            bin_name: darya.exe
+            archive_ext: zip
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -86,26 +99,59 @@ jobs:
         if: matrix.use_cross == true
         run: cargo install cross --locked
 
-      - name: Build binaries
+      - name: Build binaries (Unix)
+        if: matrix.os != 'windows-latest'
+        shell: bash
         run: |
           if [ "${{ matrix.use_cross }}" = "true" ]; then
-            cross build --release --target "${{ matrix.target }}" --bin darya
+            cross build --release --target "${{ matrix.target }}" --bin ${{ matrix.bin_name }}
           else
-            cargo build --release --target "${{ matrix.target }}" --bin darya
+            cargo build --release --target "${{ matrix.target }}" --bin ${{ matrix.bin_name }}
           fi
 
-      - name: Archive artifacts
+      - name: Build binaries (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          if ("${{ matrix.use_cross }}" -eq "true") {
+            cross build --release --target "${{ matrix.target }}" --bin ${{ matrix.bin_name }}
+          } else {
+            cargo build --release --target "${{ matrix.target }}" --bin ${{ matrix.bin_name }}
+          }
+          
+
+      - name: Archive artifacts (Unix)
+        if: matrix.os != 'windows-latest'
         run: |
           ARTIFACT_NAME="darya-${{ matrix.target }}"
           DIST_DIR="dist"
           mkdir -p "${DIST_DIR}"
-          tar -czf "${DIST_DIR}/${ARTIFACT_NAME}.tar.gz" -C "target/${{ matrix.target }}/release" darya
+          tar -czf "${DIST_DIR}/${ARTIFACT_NAME}.${{ matrix.archive_ext }}" -C "target/${{ matrix.target }}/release" ${{ matrix.bin_name }}
 
-      - name: Upload artifacts
+      - name: Upload artifacts (Unix)
+        if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
           name: darya-${{ matrix.target }}
-          path: dist/darya-${{ matrix.target }}.tar.gz
+          path: dist/darya-${{ matrix.target }}.${{ matrix.archive_ext }}
+
+      - name: Archive artifacts (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $artifactName = "darya-${{ matrix.target }}"
+          $distDir = "dist"
+          New-Item -ItemType Directory -Force -Path $distDir | Out-Null
+          $binPath = "target/${{ matrix.target }}/release/${{ matrix.bin_name }}"
+          $zipPath = "$distDir/$artifactName.${{ matrix.archive_ext }}"
+          Compress-Archive -Path $binPath -DestinationPath $zipPath
+
+      - name: Upload artifacts (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: darya-${{ matrix.target }}
+          path: dist/darya-${{ matrix.target }}.${{ matrix.archive_ext }}
 
   release:
     runs-on: ubuntu-latest
@@ -127,6 +173,8 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
-          files: dist/**/*.tar.gz
+          files: |
+            dist/**/*.tar.gz
+            dist/**/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@
 
 The interface is straightforward and easy to navigate, letting you move through directories, run scans when you want, and focus on the information that actually matters. It’s designed to stay fast and responsive, keeping things simple while working reliably across POSIX-like systems.
 
-Darya now also runs on Windows (MSVC), so the same keyboard-driven UI is available inside Windows terminals just like on Linux and macOS.
-
 <img src="https://github.com/user-attachments/assets/9977c103-7b4b-4734-8ff4-4781b65be9c9" />
 
 ## Installation
@@ -63,18 +61,6 @@ Darya now also runs on Windows (MSVC), so the same keyboard-driven UI is availab
    ```bash
    cargo install --path .
    ```
-
-### Windows support
-- Install the Visual Studio Build Tools (or the full Visual Studio Desktop C++ workload) to pull in the MSVC linker and headers required by the Windows toolchain.
-- Add the MSVC Rust target with:
-  ```bash
-  rustup target add x86_64-pc-windows-msvc
-  ```
-- From a Developer Command Prompt or an administrative PowerShell session, run:
-  ```bash
-  cargo install darya
-  ```
-- Run `cargo test` followed by `cargo build --release` on Windows to validate the build before tagging a release; the info panel in the UI surfaces Windows-specific attributes when the app is running on that platform.
 
 ## Quick start
 - Launch `darya` in any directory to open the UI, then press `R` to start a scan.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 The interface is straightforward and easy to navigate, letting you move through directories, run scans when you want, and focus on the information that actually matters. It’s designed to stay fast and responsive, keeping things simple while working reliably across POSIX-like systems.
 
+Darya now also runs on Windows (MSVC), so the same keyboard-driven UI is available inside Windows terminals just like on Linux and macOS.
+
 <img src="https://github.com/user-attachments/assets/9977c103-7b4b-4734-8ff4-4781b65be9c9" />
 
 ## Installation
@@ -61,6 +63,18 @@ The interface is straightforward and easy to navigate, letting you move through 
    ```bash
    cargo install --path .
    ```
+
+### Windows support
+- Install the Visual Studio Build Tools (or the full Visual Studio Desktop C++ workload) to pull in the MSVC linker and headers required by the Windows toolchain.
+- Add the MSVC Rust target with:
+  ```bash
+  rustup target add x86_64-pc-windows-msvc
+  ```
+- From a Developer Command Prompt or an administrative PowerShell session, run:
+  ```bash
+  cargo install darya
+  ```
+- Run `cargo test` followed by `cargo build --release` on Windows to validate the build before tagging a release; the info panel in the UI surfaces Windows-specific attributes when the app is running on that platform.
 
 ## Quick start
 - Launch `darya` in any directory to open the UI, then press `R` to start a scan.

--- a/src/app/scan/scanner.rs
+++ b/src/app/scan/scanner.rs
@@ -13,12 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::platform::metadata::{
+    DeviceId, HardLinkKey, device_id, disk_usage_bytes, hard_link_key,
+};
 use crate::tree::NodeType;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use std::collections::HashSet;
 use std::ffi::OsStr;
-#[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
 use std::{
     path::PathBuf,
     sync::{
@@ -151,17 +152,17 @@ fn run_scan(
 ) {
     let mut scanned = 0;
     let mut errors = 0;
-    let mut seen_links: HashSet<(u64, u64)> = HashSet::new();
+    let mut seen_links: HashSet<HardLinkKey> = HashSet::new();
 
     let custom_same_fs = options.same_file_system && cfg!(unix);
     #[cfg(unix)]
-    let root_dev = if custom_same_fs {
-        root.metadata().ok().map(|meta| meta.dev())
+    let root_dev: Option<DeviceId> = if custom_same_fs {
+        root.metadata().ok().and_then(|meta| device_id(&meta))
     } else {
         None
     };
     #[cfg(not(unix))]
-    let root_dev = None;
+    let root_dev: Option<DeviceId> = None;
 
     let walker = WalkDir::new(&root).follow_links(options.follow_symlinks);
     let walker = if options.same_file_system && !custom_same_fs {
@@ -214,9 +215,9 @@ fn run_scan(
                 match entry.metadata() {
                     Ok(metadata) => {
                         if custom_same_fs
-                            && let Some(root_dev) = root_dev
+                            && let Some(root_dev) = root_dev.as_ref()
                             && let Some(entry_dev) = device_id(&metadata)
-                            && entry_dev != root_dev
+                            && entry_dev != *root_dev
                         {
                             activity.skipped_mounts += 1;
                             if entry.file_type().is_dir() {
@@ -333,28 +334,6 @@ fn build_excludes(patterns: &[String]) -> Option<GlobSet> {
     builder.build().ok()
 }
 
-#[cfg(unix)]
-fn hard_link_key(metadata: &std::fs::Metadata) -> Option<(u64, u64)> {
-    use std::os::unix::fs::MetadataExt;
-    Some((metadata.dev(), metadata.ino()))
-}
-
-#[cfg(not(unix))]
-fn hard_link_key(_metadata: &std::fs::Metadata) -> Option<(u64, u64)> {
-    None
-}
-
-#[cfg(unix)]
-fn disk_usage_bytes(metadata: &std::fs::Metadata) -> u64 {
-    use std::os::unix::fs::MetadataExt;
-    metadata.blocks().saturating_mul(512)
-}
-
-#[cfg(not(unix))]
-fn disk_usage_bytes(metadata: &std::fs::Metadata) -> u64 {
-    metadata.len()
-}
-
 fn is_cache_entry(entry: &DirEntry) -> bool {
     entry
         .path()
@@ -405,16 +384,6 @@ fn classify(entry: &walkdir::DirEntry) -> NodeType {
     } else {
         NodeType::File
     }
-}
-
-#[cfg(unix)]
-fn device_id(metadata: &std::fs::Metadata) -> Option<u64> {
-    Some(metadata.dev())
-}
-
-#[cfg(not(unix))]
-fn device_id(_metadata: &std::fs::Metadata) -> Option<u64> {
-    None
 }
 
 #[cfg(test)]

--- a/src/platform/metadata.rs
+++ b/src/platform/metadata.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 M.R. Siavash Katebzadeh <mr@katebzadeh.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::fs::Metadata;
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+#[cfg(windows)]
+use std::os::windows::fs::MetadataExt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct DeviceId(u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct HardLinkKey {
+    device: DeviceId,
+    index: u64,
+}
+
+impl HardLinkKey {
+    pub fn new(device: DeviceId, index: u64) -> Self {
+        Self { device, index }
+    }
+}
+
+#[cfg(unix)]
+pub fn device_id(metadata: &Metadata) -> Option<DeviceId> {
+    Some(DeviceId(metadata.dev()))
+}
+
+#[cfg(windows)]
+pub fn device_id(metadata: &Metadata) -> Option<DeviceId> {
+    Some(DeviceId(metadata.volume_serial_number() as u64))
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn device_id(_: &Metadata) -> Option<DeviceId> {
+    None
+}
+
+#[cfg(unix)]
+pub fn hard_link_key(metadata: &Metadata) -> Option<HardLinkKey> {
+    Some(HardLinkKey::new(DeviceId(metadata.dev()), metadata.ino()))
+}
+
+#[cfg(windows)]
+pub fn hard_link_key(metadata: &Metadata) -> Option<HardLinkKey> {
+    Some(HardLinkKey::new(
+        DeviceId(metadata.volume_serial_number() as u64),
+        metadata.file_index(),
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn hard_link_key(_: &Metadata) -> Option<HardLinkKey> {
+    None
+}
+
+#[cfg(unix)]
+pub fn disk_usage_bytes(metadata: &Metadata) -> u64 {
+    metadata.blocks() * 512
+}
+
+#[cfg(windows)]
+pub fn disk_usage_bytes(metadata: &Metadata) -> u64 {
+    metadata.allocation_size()
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn disk_usage_bytes(metadata: &Metadata) -> u64 {
+    metadata.len()
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -13,23 +13,4 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod app;
-pub mod events;
-pub mod platform;
-pub mod ui;
-
-pub use app::cli;
-pub use app::config;
-pub use app::input;
-pub use app::scan;
-pub use app::scan::accumulator as scan_accumulator;
-pub use app::scan::control as scan_control;
-pub use app::scan::manager as scan_manager;
-pub use app::scan::scanner as fs_scan;
-pub use app::size;
-pub use app::snapshot;
-pub use app::state;
-pub use app::tree;
-pub use ui::display;
-pub use ui::theme;
-pub use ui::treemap;
+pub mod metadata;

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -234,7 +234,19 @@ pub(crate) fn selected_info_line(state: &AppState) -> String {
         )
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        let attrs = metadata.file_attributes();
+        let index = metadata.file_index();
+        let serial = metadata.volume_serial_number();
+        let readonly = metadata.permissions().readonly();
+        format!(
+            "info: attrs={attrs:#x} index={index} serial={serial} readonly={readonly} mtime={modified}"
+        )
+    }
+
+    #[cfg(all(not(unix), not(windows)))]
     {
         format!(
             "info: readonly={} mtime={modified}",
@@ -520,6 +532,8 @@ mod tests {
         assert!(info.contains("mtime="));
         #[cfg(unix)]
         assert!(info.contains("uid="));
+        #[cfg(windows)]
+        assert!(info.contains("index="));
 
         let _ = fs::remove_file(temp);
     }


### PR DESCRIPTION
Resolves #10 by implementing a shared `platform::metadata` module so `scanner` can work with typed device IDs, hard-link keys, and disk usage on Unix and Windows
